### PR TITLE
Adds rules for Surface Pro 2017

### DIFF
--- a/root/etc/udev/rules.d/99-ipts.rules
+++ b/root/etc/udev/rules.d/99-ipts.rules
@@ -9,3 +9,9 @@ SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:005E SingleTouch", ENV{ID_INPUT_TOU
 
 # IPTS Pen (SB)
 SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:005E Pen", SYMLINK+="input/pen"
+#
+# IPTS Touchscreen (SP2017)
+SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:001F SingleTouch", ENV{ID_INPUT_TOUCHSCREEN}="1", SYMLINK+="input/touchscreen"
+
+# IPTS Pen (SP2017)
+SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:001F Pen", SYMLINK+="input/pen"


### PR DESCRIPTION
Your kernel is the best I've tried so far on the 2017 Surface Pro.
This adds the udev rules for the touchscreen and pen.
The pen currently isn't working for me, but it does detect the device.