### PR TITLE
Sets the INPUT_PROP_DIRECT bit on the stylus input.

### DIFF
--- a/kernel/drivers/hid/hid-multitouch.c
+++ b/kernel/drivers/hid/hid-multitouch.c
@@ -1155,6 +1155,7 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
 		suffix = "Pen";
 		/* force BTN_STYLUS to allow tablet matching in udev */
 		__set_bit(BTN_STYLUS, hi->input->keybit);
+        __set_bit(INPUT_PROP_DIRECT, hi->input->propbit);
 	} else {
 		switch (field->application) {
 		case HID_GD_KEYBOARD:
@@ -1170,6 +1171,7 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
 			suffix = "Pen";
 			/* force BTN_STYLUS to allow tablet matching in udev */
 			__set_bit(BTN_STYLUS, hi->input->keybit);
+            __set_bit(INPUT_PROP_DIRECT, hi->input->propbit);
 			break;
 		case HID_DG_TOUCHSCREEN:
 			suffix = "Touchscreen";


### PR DESCRIPTION
This tells userland programs (ie, libinput and libwacom) that there is a
1:1 mapping between the stylus and the screen (after scaling).

This, along with a patch to libwacom to add mei as a bus type (see my [libwacom fork](//github.com/geoffholden/libwacom/)) allows the pen input to be picked up by the wacom driver.