### PR TITLE
Add quirks for Surface Dock GigE

### DIFF
--- a/patches/4.18/0010-surface_dock.patch
+++ b/patches/4.18/0010-surface_dock.patch
@@ -1,0 +1,27 @@
+From 14a3336bbdf629ee2256609c10f111923e4b88e8 Mon Sep 17 00:00:00 2001
+From: qzed <qzed@users.noreply.github.com>
+Date: Sun, 30 Dec 2018 22:01:03 +0100
+Subject: [PATCH] Add quirks for MS Surface Dock GigE
+
+Add device quirks for the Microsoft Surface Dock USB Gigabit Ethernet
+adapter.
+---
+ drivers/usb/core/quirks.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
+index 178d6c6063c0..3de4a0574634 100644
+--- a/drivers/usb/core/quirks.c
++++ b/drivers/usb/core/quirks.c
+@@ -206,6 +206,8 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* Microsoft LifeCam-VX700 v2.0 */
+ 	{ USB_DEVICE(0x045e, 0x0770), .driver_info = USB_QUIRK_RESET_RESUME },
+ 
++	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
++
+ 	/* Logitech HD Pro Webcams C920, C920-C, C925e and C930e */
+ 	{ USB_DEVICE(0x046d, 0x082d), .driver_info = USB_QUIRK_DELAY_INIT },
+ 	{ USB_DEVICE(0x046d, 0x0841), .driver_info = USB_QUIRK_DELAY_INIT },
+-- 
+2.20.1
+


### PR DESCRIPTION
Add device quirks for the Microsoft Surface Dock Gigabit Ethernet adapter.

Fixes #259.