### PR TITLE
Update button patch

### DIFF
--- a/patches/4.18/0003-buttons.patch
+++ b/patches/4.18/0003-buttons.patch
@@ -1,18 +1,18 @@
-From ac9ac2a05180af9e356f2f4d6840b132b1fb45f7 Mon Sep 17 00:00:00 2001
+From dccd71252db55e388c31b55aedcb473ee9fd1df7 Mon Sep 17 00:00:00 2001
 From: qzed <qzed@users.noreply.github.com>
-Date: Mon, 24 Dec 2018 14:05:07 +0100
+Date: Sun, 6 Jan 2019 16:02:24 +0100
 Subject: [PATCH 3/8] buttons
 
 ---
- drivers/input/misc/soc_button_array.c     | 67 +++++++++++++++++++++--
- drivers/platform/x86/surfacepro3_button.c |  9 +++
- 2 files changed, 70 insertions(+), 6 deletions(-)
+ drivers/input/misc/soc_button_array.c     | 84 +++++++++++++++++++++--
+ drivers/platform/x86/surfacepro3_button.c | 36 ++++++++++
+ 2 files changed, 114 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/input/misc/soc_button_array.c b/drivers/input/misc/soc_button_array.c
-index 23520df7650f..d74f8c3dd54b 100644
+index 23520df7650f..1ea239ff426d 100644
 --- a/drivers/input/misc/soc_button_array.c
 +++ b/drivers/input/misc/soc_button_array.c
-@@ -29,12 +29,20 @@ struct soc_button_info {
+@@ -29,12 +29,24 @@ struct soc_button_info {
  	bool wakeup;
  };
  
@@ -29,12 +29,16 @@ index 23520df7650f..d74f8c3dd54b 100644
   * buttons into them based on whether the key should be auto repeat.
   */
 -#define BUTTON_TYPES	2
-+#define BUTTON_TYPES            2
-+#define SURFACE_METHOD_DSM      "_DSM"
++#define BUTTON_TYPES            	2
++
++#define MSHW0040_DSM_REVISION		0x01
++#define MSHW0040_DSM_GET_OMPR		0x02	// get OEM Platform Revision
++static const guid_t MSHW0040_DSM_UUID =
++	GUID_INIT(0x6fd05c69, 0xcde3, 0x49f4, 0x95, 0xed, 0xab, 0x16, 0x65, 0x49, 0x80, 0x35);
  
  struct soc_button_data {
  	struct platform_device *children[BUTTON_TYPES];
-@@ -310,6 +318,7 @@ static int soc_button_probe(struct platform_device *pdev)
+@@ -310,6 +322,7 @@ static int soc_button_probe(struct platform_device *pdev)
  {
  	struct device *dev = &pdev->dev;
  	const struct acpi_device_id *id;
@@ -42,7 +46,7 @@ index 23520df7650f..d74f8c3dd54b 100644
  	struct soc_button_info *button_info;
  	struct soc_button_data *priv;
  	struct platform_device *pd;
-@@ -320,12 +329,20 @@ static int soc_button_probe(struct platform_device *pdev)
+@@ -320,12 +333,20 @@ static int soc_button_probe(struct platform_device *pdev)
  	if (!id)
  		return -ENODEV;
  
@@ -66,7 +70,7 @@ index 23520df7650f..d74f8c3dd54b 100644
  	}
  
  	error = gpiod_count(dev, NULL);
-@@ -357,7 +374,7 @@ static int soc_button_probe(struct platform_device *pdev)
+@@ -357,7 +378,7 @@ static int soc_button_probe(struct platform_device *pdev)
  	if (!priv->children[0] && !priv->children[1])
  		return -ENODEV;
  
@@ -75,7 +79,7 @@ index 23520df7650f..d74f8c3dd54b 100644
  		devm_kfree(dev, button_info);
  
  	return 0;
-@@ -377,9 +394,47 @@ static struct soc_button_info soc_button_PNP0C40[] = {
+@@ -377,9 +398,60 @@ static struct soc_button_info soc_button_PNP0C40[] = {
  	{ }
  };
  
@@ -89,14 +93,27 @@ index 23520df7650f..d74f8c3dd54b 100644
 + * Both, the Surface Pro 4 (surfacepro3_button.c) and the above mentioned
 + * devices use MSHW0040 for power and volume buttons, however the way they
 + * have to be addressed differs. Make sure that we only load this drivers
-+ * for the correct devices by checking if the _DSM method exists.
++ * for the correct devices by checking the OEM Platform Revision provided by
++ * the _DSM method.
 + */
 +static int soc_device_check_MSHW0040(struct device *dev)
 +{
-+	if (!acpi_has_method(ACPI_HANDLE(dev), SURFACE_METHOD_DSM))
-+		return -ENODEV;
++	acpi_handle handle = ACPI_HANDLE(dev);
++	union acpi_object *result;
++	u64 oem_platform_rev = 0;
 +
-+	return 0;
++	// get OEM board revision
++	result = acpi_evaluate_dsm_typed(handle, &MSHW0040_DSM_UUID, MSHW0040_DSM_REVISION,
++	                                 MSHW0040_DSM_GET_OMPR, NULL, ACPI_TYPE_INTEGER);
++
++	if (result) {
++		oem_platform_rev = result->integer.value;
++		ACPI_FREE(result);
++	}
++
++	dev_dbg(dev, "OEM Platform Revision %llu\n", oem_platform_rev);
++
++	return oem_platform_rev > 0 ? 0 : -ENODEV;
 +}
 +
 +/*
@@ -125,28 +142,62 @@ index 23520df7650f..d74f8c3dd54b 100644
  };
  
 diff --git a/drivers/platform/x86/surfacepro3_button.c b/drivers/platform/x86/surfacepro3_button.c
-index 1b491690ce07..006c94eda7be 100644
+index 1b491690ce07..b8f9c91873c7 100644
 --- a/drivers/platform/x86/surfacepro3_button.c
 +++ b/drivers/platform/x86/surfacepro3_button.c
-@@ -22,6 +22,7 @@
- #define SURFACE_PRO3_BUTTON_HID		"MSHW0028"
- #define SURFACE_PRO4_BUTTON_HID		"MSHW0040"
+@@ -24,6 +24,12 @@
  #define SURFACE_BUTTON_OBJ_NAME		"VGBI"
-+#define SURFACE_METHOD_DSM		"_DSM"
  #define SURFACE_BUTTON_DEVICE_NAME	"Surface Pro 3/4 Buttons"
  
++#define MSHW0040_DSM_REVISION		0x01
++#define MSHW0040_DSM_GET_OMPR		0x02	// get OEM Platform Revision
++static const guid_t MSHW0040_DSM_UUID =
++	GUID_INIT(0x6fd05c69, 0xcde3, 0x49f4, 0x95, 0xed, 0xab, 0x16, 0x65, 0x49, 0x80, 0x35);
++
++
  #define SURFACE_BUTTON_NOTIFY_TABLET_MODE	0xc8
-@@ -158,6 +159,14 @@ static int surface_button_add(struct acpi_device *device)
+ 
+ #define SURFACE_BUTTON_NOTIFY_PRESS_POWER	0xc6
+@@ -146,6 +152,32 @@ static int surface_button_resume(struct device *dev)
+ }
+ #endif
+ 
++/*
++ * Surface Pro 4 and Surface Book 2 / Surface Pro 2017 use the same device
++ * ID (MSHW0040) for the power/volume buttons. Make sure this is the right
++ * device by checking for the _DSM method and OEM Platform Revision.
++ */
++static int surface_button_check_MSHW0040(struct device *dev)
++{
++	acpi_handle handle = ACPI_HANDLE(dev);
++	union acpi_object *result;
++	u64 oem_platform_rev = 0;
++
++	// get OEM board revision
++	result = acpi_evaluate_dsm_typed(handle, &MSHW0040_DSM_UUID, MSHW0040_DSM_REVISION,
++	                                 MSHW0040_DSM_GET_OMPR, NULL, ACPI_TYPE_INTEGER);
++
++	if (result) {
++		oem_platform_rev = result->integer.value;
++		ACPI_FREE(result);
++	}
++
++	dev_dbg(dev, "OEM Platform Revision %llu\n", oem_platform_rev);
++
++	return oem_platform_rev == 0 ? 0 : -ENODEV;
++}
++
++
+ static int surface_button_add(struct acpi_device *device)
+ {
+ 	struct surface_button *button;
+@@ -158,6 +190,10 @@ static int surface_button_add(struct acpi_device *device)
  	    strlen(SURFACE_BUTTON_OBJ_NAME)))
  		return -ENODEV;
  
-+	/*
-+	 * Surface Pro 4 and Surface Book 2 / Surface Pro 2017 use the same device
-+	 * ID (MSHW0040) for the power/volume buttons. Make sure this is the right
-+	 * device by checking for the _DSM method.
-+	 */
-+	if (acpi_has_method(device->handle, SURFACE_METHOD_DSM))
-+		return -ENODEV;
++	error = surface_button_check_MSHW0040(&device->dev);
++	if (error)
++		return error;
 +
  	button = kzalloc(sizeof(struct surface_button), GFP_KERNEL);
  	if (!button)


### PR DESCRIPTION
Update device check to avoid wrongfully probing and attaching on Surface Book 1.

Fixes #243 and #224.