### PR TITLE
Prompt user for all installations and make a setup.conf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+setup.conf

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,19 @@
 LX_BASE=""
 LX_VERSION=""
 
+if [ -e setup.conf ]; then
+	echo "Saved configuration:"
+	cat ./setup.conf
+	echo ""
+	read -rp "Do you want to use this configuration? (type yes or no) " setupconfig;echo
+	if [ "$setupconfig" = "yes" ]; then
+		echo "Loading config from setup.conf"
+		. ./setup.conf
+	else
+		echo "Not loading setup.conf. Will prompt user."
+	fi
+fi
+
 if [ -r /etc/os-release ]; then
     . /etc/os-release
 	if [ $ID = arch ]; then
@@ -37,7 +50,9 @@ for dir in $(ls root/); do cp -Rb root/$dir/* /$dir/; done
 echo "Making /lib/systemd/system-sleep/sleep executable...\n"
 chmod a+x /lib/systemd/system-sleep/sleep
 
-read -rp "Do you want to replace suspend with hibernate? (type yes or no) " usehibernate;echo
+if [ -z "${usehibernate}" ]; then
+	read -rp "Do you want to replace suspend with hibernate? (type yes or no) " usehibernate;echo
+fi
 
 if [ "$usehibernate" = "yes" ]; then
 	if [ "$LX_BASE" = "ubuntu" ] && [ 1 -eq "$(echo "${LX_VERSION} >= 17.10" | bc)" ]; then
@@ -51,7 +66,9 @@ else
 	echo "Not touching Suspend\n"
 fi
 
-read -rp "Do you want use the patched libwacom packages? (type yes or no) " uselibwacom;echo
+if [ -z "${uselibwacom}" ]; then
+	read -rp "Do you want use the patched libwacom packages? (type yes or no) " uselibwacom;echo
+fi
 
 if [ "$uselibwacom" = "yes" ]; then
 	echo "Installing patched libwacom packages..."
@@ -61,7 +78,9 @@ else
 	echo "Not touching libwacom"
 fi
 
-read -rp "Do you want to remove the example intel xorg config? (type yes or no) " removexorg;echo
+if [ -z "${removexorg}" ]; then
+	read -rp "Do you want to remove the example intel xorg config? (type yes or no) " removexorg;echo
+fi
 
 if [ "$removexorg" = "yes" ]; then
 	echo "Removing the example intel xorg config..."
@@ -70,7 +89,9 @@ else
 	echo "Not touching example intel xorg config (/etc/X11/xorg.conf.d/20-intel_example.conf)"
 fi
 
-read -rp "Do you want to remove the example pulse audio config files? (type yes or no) " removepulse;echo
+if [ -z "${removepulse}" ]; then
+	read -rp "Do you want to remove the example pulse audio config files? (type yes or no) " removepulse;echo
+fi
 
 if [ "$removepulse" = "yes" ]; then
 	echo "Removing the example pulse audio config files..."
@@ -210,7 +231,9 @@ echo "Installing mwlwifi firmware...\n"
 mkdir -p /lib/firmware/mwlwifi/
 unzip -o firmware/mwlwifi_firmware.zip -d /lib/firmware/mwlwifi/
 
-read -rp "Do you want to set your clock to local time instead of UTC? This fixes issues when dual booting with Windows. (type yes or no) " uselocaltime;echo
+if [ -z "${uselocaltime}" ]; then
+	read -rp "Do you want to set your clock to local time instead of UTC? This fixes issues when dual booting with Windows. (type yes or no) " uselocaltime;echo
+fi
 
 if [ "$uselocaltime" = "yes" ]; then
 	echo "Setting clock to local time...\n"
@@ -221,21 +244,64 @@ else
 	echo "Not setting clock"
 fi
 
-read -rp "Do you want this script to download and install the latest kernel for you? (type yes or no) " autoinstallkernel;echo
+if [ -z "${autoinstallkernel}" ]; then
+	read -rp "Do you want this script to download and install the latest kernel for you? (type yes or no) " autoinstallkernel;echo
+fi
 
 if [ "$autoinstallkernel" = "yes" ]; then
-	echo "Downloading latest kernel...\n"
 
-	urls=$(curl --silent "https://api.github.com/repos/jakeday/linux-surface/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/')
+	json=$(curl --silent "https://api.github.com/repos/jakeday/linux-surface/releases/latest")
+	if [ -e /usr/bin/jq ]
+	then
+		echo "Checking if the latest kernel version is already installed.\n"
+		LATESTKERNELVERSION=$(echo $json | jq .tag_name | cut -d '-' -f1 | tr -d '"')
+		LATESTKERNELVERSIONINSTALLED=$(dpkg -l | grep linux-image-$LATESTKERNELVERSION)
+		if [ $? = "0" ]; then
+			read -rp "Latest kernel version is already installed. Do you want to redownload and reinstall the latest kernel? (type yes or no) " INSTALLKERNEL;echo
+		else
+			echo "Latest kernel version is not installed, will download.\n"
+			INSTALLKERNEL='yes'
+		fi
+	else
+		INSTALLKERNEL="yes"	
+	fi
 
-	resp=$(wget -P tmp $urls)
+	if [ "$INSTALLKERNEL" = "yes" ]; then
+		echo "Downloading latest kernel...\n"
 
-	echo "Installing latest kernel...\n"
+		urls=$(curl --silent "https://api.github.com/repos/jakeday/linux-surface/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/')
 
-	dpkg -i tmp/*.deb
-	rm -rf tmp
+		resp=$(wget -P tmp $urls)
+
+		echo "Installing latest kernel...\n"
+
+		dpkg -i tmp/*.deb
+		rm -rf tmp
+	else
+		echo "Latest kernel already installed, Not redownloading\n"
+	fi
 else
 	echo "Not downloading latest kernel"
+fi
+
+if [ "$setupconfig" = "no" -o ! -e setup.conf ]; then
+	read -rp "Do you want to save your answers to setup.conf? (type yes or no) " saveconfig;echo
+	if [ "$saveconfig" = "yes" ]; then
+		echo "Saving answers to setup.conf\n"
+		#echo "copyroot=$copyroot" > setup.conf
+		#echo "sleepexecutable=$sleepexecutable" >> setup.conf
+		echo "usehibernate=$usehibernate" >> setup.conf
+		echo "uselibwacom=$uselibwacom" >> setup.conf
+		echo "removexorg=$removexorg" >> setup.conf
+		echo "removepulse=$removepulse" >> setup.conf
+		#echo "iptsfirmware=$iptsfirmware" >> setup.conf
+		#echo "marvellfirmware=$marvellfirmware" >> setup.conf
+		#echo "mwlwifi=$mwlwifi" >> setup.conf
+		echo "uselocaltime=$uselocaltime" >> setup.conf
+		echo "autoinstallkernel=$autoinstallkernel" >> setup.conf
+	else
+		echo "Not saving answers.\n"
+	fi
 fi
 
 echo "\nAll done! Please reboot."


### PR DESCRIPTION
These are some changes I made to the setup.sh file so it will prompt for all of the installations and also saves a setup.conf file so the next time you run it you can easily select the same options (for installing new kernels or updates from the repo). It also checks if the running kernel is the same as the latest and prompts the user if it should be redownloaded and reinstalled.

I added these as I was tired of trying to remember all the options I had selected when debugging why rotation was failing after installing using the script.