### PR TITLE
mwifiex: fix disable_auto_ds param

### DIFF
--- a/patches/4.19/0008-wifi.patch
+++ b/patches/4.19/0008-wifi.patch
@@ -1,6 +1,6 @@
-From 6b592ac2fb808cc68d3d7fb65039ce6795636226 Mon Sep 17 00:00:00 2001
-From: Jake Day <jake@ninebysix.com>
-Date: Thu, 31 Jan 2019 07:12:13 -0500
+From f9652f7214abca6982c9c200a23c4724e4953c8f Mon Sep 17 00:00:00 2001
+From: "Hayataka@kitakar5525" <34676735+kitakar5525@users.noreply.github.com>
+Date: Tue, 5 Feb 2019 18:04:58 +0900
 Subject: [PATCH 08/11] wifi
 
 ---
@@ -197,18 +197,18 @@ index 3fe81b2a929a..6e734a83e6bf 100644
  	skb_trim(skb, rx_len);
  
 diff --git a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
-index 4ed10cf82f9a..3218a8f3d91f 100644
+index 4ed10cf82f9a..5019e75169c7 100644
 --- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
 +++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
-@@ -31,7 +31,7 @@ module_param(drcs, bool, 0644);
+@@ -30,7 +30,7 @@ static bool drcs;
+ module_param(drcs, bool, 0644);
  MODULE_PARM_DESC(drcs, "multi-channel operation:1, single-channel operation:0");
  
- static bool disable_auto_ds;
--module_param(disable_auto_ds, bool, 0);
-+module_param(disable_auto_ds, bool, 1);
+-static bool disable_auto_ds;
++static bool disable_auto_ds = 1;
+ module_param(disable_auto_ds, bool, 0);
  MODULE_PARM_DESC(disable_auto_ds,
  		 "deepsleep enabled=0(default), deepsleep disabled=1");
- /*
 diff --git a/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c b/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c
 index 69e3b624adbb..884bad677cc3 100644
 --- a/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c
@@ -248,5 +248,5 @@ diff --git a/scripts/leaking_addresses.pl b/scripts/leaking_addresses.pl
 old mode 100755
 new mode 100644
 -- 
-2.17.1
+2.20.1
 


### PR DESCRIPTION
The third parameter of `module_param` is for permission ([moduleparam.h#L107](https://elixir.bootlin.com/linux/v4.19.19/source/include/linux/moduleparam.h#L107)). This commit correctly sets default value of `disable_auto_ds` to `1`.

```diff
diff --git a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
index 3218a8f3d..5019e7516 100644
--- a/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
+++ b/drivers/net/wireless/marvell/mwifiex/sta_cmd.c
@@ -30,8 +30,8 @@ static bool drcs;
 module_param(drcs, bool, 0644);
 MODULE_PARM_DESC(drcs, "multi-channel operation:1, single-channel operation:0");
 
-static bool disable_auto_ds;
-module_param(disable_auto_ds, bool, 1);
+static bool disable_auto_ds = 1;
+module_param(disable_auto_ds, bool, 0);
 MODULE_PARM_DESC(disable_auto_ds,
 		 "deepsleep enabled=0(default), deepsleep disabled=1");
 /*
```

and fixes below dmesg output:

```
------------[ cut here ]------------
Attribute disable_auto_ds: Invalid permissions 01
WARNING: CPU: 3 PID: 289 at fs/sysfs/group.c:60 internal_create_group+0x303/0x380
Modules linked in: mwifiex(+) snd_compress ac97_bus snd_pcm_dmaengine snd_hda_intel hid_sensor_hub hid_multitouch(+) crct10dif_pcl>
 vfio_iommu_type1 vfio kvm irqbypass i2c_algo_bit drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops drm intel_agp intel>
CPU: 3 PID: 289 Comm: systemd-udevd Tainted: G     U     OE     4.20.6-arch1-1-surface #1
Hardware name: Microsoft Corporation Surface Book/Surface Book, BIOS 91.2327.769 08/23/2018
RIP: 0010:internal_create_group+0x303/0x380
Code: 89 4c 24 0c e8 98 48 d8 ff 0f 0b 49 8b 37 8b 4c 24 0c e9 4d ff ff ff 48 8b 36 48 c7 c7 80 e5 cb a3 89 4c 24 0c e8 77 48 d8 f>
RSP: 0018:ffffa3d781e13c48 EFLAGS: 00010286
RAX: 0000000000000000 RBX: ffff8c0919cabc08 RCX: 0000000000000000
RDX: 0000000000000007 RSI: ffffffffa3ca47d6 RDI: 00000000ffffffff
RBP: ffffffffc0c67150 R08: 0000000000000001 R09: 000000000000031f
R10: 0000000000000001 R11: 0000000000000000 R12: ffff8c090f5acc38
R13: 0000000000000000 R14: 0000000000000002 R15: ffff8c090f619300
FS:  00007f4e50184cc0(0000) GS:ffff8c091f380000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 0000559348e1eea4 CR3: 00000004590ce005 CR4: 00000000003606e0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
Call Trace:
 module_param_sysfs_setup+0x6d/0xd0
 mod_sysfs_setup+0xe5/0x610
 load_module+0x1fd5/0x2290
 ? vmap_page_range_noflush+0x23f/0x350
 ? __se_sys_init_module+0x10a/0x170
 __se_sys_init_module+0x10a/0x170
 do_syscall_64+0x5b/0x170
 entry_SYSCALL_64_after_hwframe+0x44/0xa9
RIP: 0033:0x7f4e51c0256e
Code: 48 8b 0d f5 18 0c 00 f7 d8 64 89 01 48 83 c8 ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 49 89 ca b8 af 00 00 00 0f 0>
RSP: 002b:00007ffd02009e98 EFLAGS: 00000246 ORIG_RAX: 00000000000000af
RAX: ffffffffffffffda RBX: 000055c050ce2da0 RCX: 00007f4e51c0256e
RDX: 00007f4e5167aecd RSI: 0000000000099849 RDI: 000055c0516b6e20
RBP: 00007f4e5167aecd R08: 0000000000000005 R09: 0000000000000004
R10: 000055c050cc9010 R11: 0000000000000246 R12: 000055c0516b6e20
R13: 000055c050ce14f0 R14: 0000000000020000 R15: 000055c050ce2da0
---[ end trace 06c3f222d649f0d9 ]---
```

By the way, we can see `disable_auto_ds` value if we set permission from `0` to `0444`  like this: `module_param(disable_auto_ds, bool, 0444);`
```bash
cat /sys/module/mwifiex/parameters/disable_auto_ds 
Y
```