### PR TITLE
Adding touchscreen and pen udev rules for SP6

### DIFF
--- a/root/etc/udev/rules.d/99-touchscreens.rules
+++ b/root/etc/udev/rules.d/99-touchscreens.rules
@@ -22,6 +22,12 @@ SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:001F Touchscreen", ENV{ID_INPUT_TOU
 # IPTS Pen (SP2017)
 SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:001F Pen", SYMLINK+="input/pen"
 
+# IPTS Touchscreen (SP6)
+SUBSYSTEMS=="input", ATTRS{name}=="ipts 045E:001F Touchscreen", ENV{ID_INPUT_TOUCHSCREEN}="1", SYMLINK+="input/touchscreen"
+
+# IPTS Pen (SP6)
+SUBSYSTEMS=="input", ATTRS{name}=="ipts 045E:001F Pen", SYMLINK+="input/pen"
+
 # IPTS Touchscreen (SB)
 SUBSYSTEMS=="input", ATTRS{name}=="ipts 1B96:005E Touchscreen", ENV{ID_INPUT_TOUCHSCREEN}="1", SYMLINK+="input/touchscreen"
 


### PR DESCRIPTION
FYI, I'm not directly using this repo, but have been using the information and the patches on NixOS, as such the changes have been made without directly testing them, i.e. you should probably check I've cut and pasted the ipts ids from the `dmesg` output correctly!

This is the filtered `dmesg` output from my Surface Pro 6, running the normal NixOS 19.03 kernel (4.19.36) with all the patches from the `patches/4.19` directory applied, as well as the relevant SP6 firmware files installed.

```
$ dmesg | grep ipts
[    2.848003] ipts: initializing ipts
[    2.848106] ipts: Intel iTouch framework initialized
[    2.979224] IPTS ipts_mei_cl_init() is called
[    2.990422] input: ipts 045E:001F UNKNOWN as /devices/pci0000:00/0000:00:16.4/mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F/0044:045E:001F.0002/input/input31
[    2.990596] input: ipts 045E:001F Pen as /devices/pci0000:00/0000:00:16.4/mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F/0044:045E:001F.0002/input/input33
[    2.990807] input: ipts 045E:001F Touchscreen as /devices/pci0000:00/0000:00:16.4/mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F/0044:045E:001F.0002/input/input34
[    2.991662] input: ipts 045E:001F Mouse as /devices/pci0000:00/0000:00:16.4/mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F/0044:045E:001F.0002/input/input35
[    2.991766] input: ipts 045E:001F UNKNOWN as /devices/pci0000:00/0000:00:16.4/mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F/0044:045E:001F.0002/input/input38
[    2.991828] hid-multitouch 0044:045E:001F.0002: input,hidraw1: <UNKNOWN> HID v3ad00.00 Mouse [ipts 045E:001F] on heci3
[    3.006688] ipts mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F: touch enabled 4
[    4.216347] ipts mei::3e8d0870-271a-4208-8eb5-9acb9402ae04:0F: touch enabled 4
```

With these 2 added `udev` rules I have both the `/dev/input/touchscreen` and `/dev/input/pen` symlinks, and touch is working in Gnome (I don't have a pen, so can't test that).