### PR TITLE
Fix for a bug in setup.sh with bad curl response

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -231,7 +231,7 @@ read -rp "Do you want this script to download and install the latest kernel for 
 if [ "$autoinstallkernel" = "yes" ]; then
 	echo "Downloading latest kernel...\n"
 
-	urls=$(curl --silent "https://api.github.com/repos/jakeday/linux-surface/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/')
+	urls=$(curl --silent "https://api.github.com/repos/jakeday/linux-surface/releases/latest" | tr ',' '\n' | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 	resp=$(wget -P tmp $urls)
 


### PR DESCRIPTION
Apparently, this call to retrieve the latest version in `setup.sh`:
```
https://api.github.com/repos/jakeday/linux-surface/releases/latest
```
is now returning a wall/blob (JSON actually, see comment below) of text instead of individual lines. This causes the grep/sed to fail badly and nothing is returned for the list of URLs. 

Simple fix, change the commas to linefeeds, making the text appear on separate lines again. 

Backward compatible so it should be fine even if the result comes back with individual lines.

Tested on Linux Mint 19.1 (Ubuntu bionic)