### PR TITLE
wpa_supplicant on resume patch for Surface Pro 6

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -12,6 +12,7 @@ case $1 in
     ;;
   post)
     # need to cycle the modules on a resume and after the reset is called, so unload...
+    pkill -f wpa_supplicant
     modprobe -r intel_ipts
     modprobe -r mei_me
     modprobe -r mei


### PR DESCRIPTION
Surface Pro 6 wifi does not resume from hibernate. Adding `pkill -f wpa_supplicant` to the sleep file before restarting the network manager effectively solves this issue. 